### PR TITLE
Feature/ansible lint action

### DIFF
--- a/.github/workflows/ansible-lint.yaml
+++ b/.github/workflows/ansible-lint.yaml
@@ -1,15 +1,15 @@
 name: Ansible Lint
-
+# Base work pulled from: https://github.com/ansible/ansible-lint-action
 on: [push, pull_request]
 
 jobs:
   build:
     runs-on: ubuntu-latest
-    
+
     steps:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0 # needed for progressive mode to work
-      
+
       - name: Ansible Linter
         uses: ansible/ansible-lint-action@main

--- a/.github/workflows/ansible-lint.yaml
+++ b/.github/workflows/ansible-lint.yaml
@@ -1,0 +1,15 @@
+name: Ansible Lint
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0 # needed for progressive mode to work
+      
+      - name: Ansible Linter
+        uses: ansible/ansible-lint-action@main

--- a/.github/workflows/ansible-lint.yaml
+++ b/.github/workflows/ansible-lint.yaml
@@ -1,6 +1,7 @@
 name: Ansible Lint
 # Base work pulled from: https://github.com/ansible/ansible-lint-action
-on: [push, pull_request]
+# Need to disable truthy check for `on` key
+on: [push, pull_request] # yamllint disable-line rule:truthy
 
 jobs:
   build:


### PR DESCRIPTION
# Summary

Adding a GitHub action to lint Ansible code. This is using the default configuration from the `ansible-lint-action` repo here: https://github.com/ansible/ansible-lint-action.