### PR TITLE
bugfix/pod-cidr: Fixing k8s config file

### DIFF
--- a/HARDWARE.md
+++ b/HARDWARE.md
@@ -7,6 +7,6 @@ This is a summary of the current hardware configuration for the cluster.
 |Hostname|Hardware|Storage|
 |--------|--------|-------|
 |node-3|Raspberry Pi 3|64 GB|
-|node-2|Raspberry Pi B+|32 GB, 32-bit CPU not compatible with k8s|
+|node-2|Raspberry Pi 4 - 4 GB|32 GB|
 |node-1|Raspberry Pi 5 - 4 GB RAM|128 GB|
 |main-node|Raspberry Pi 4 - 4 GB RAM|64 GB|

--- a/playbooks/roles/cluster_setup/tasks/nodes.yml
+++ b/playbooks/roles/cluster_setup/tasks/nodes.yml
@@ -8,6 +8,5 @@
   ansible.builtin.command:
     cmd: >
       kubeadm join
-      --discovery-token-unsafe-skip-ca-verification
       --config /etc/kubernetes/cluster-config.yml
   changed_when: true

--- a/playbooks/roles/cluster_setup/templates/cluster-config.yml.j2
+++ b/playbooks/roles/cluster_setup/templates/cluster-config.yml.j2
@@ -34,7 +34,7 @@ kind: ClusterConfiguration
 kubernetesVersion: 1.30.0
 networking:
   dnsDomain: cluster.local
-  serviceSubnet: {{ cluster_setup_pod_cidr }}
+  podSubnet: {{ cluster_setup_pod_cidr }}
 scheduler: {}
 ---
 # Join


### PR DESCRIPTION
# Summary

- Fixing HARDWARE description for NODE 2
- Fixing ClusterConfiguration/networking to use `podSubnet`

## Pod Subnet Details

During flannel rollout the pods were returning errors:
```bash
Error registering network: failed to acquire lease: node "node-2" pod cidr not assigned
```

That error indicates the pod subnet is misconfigured. Checking the k8s configuration revealed that the incorrect setting was used for setting up the pod subnet. In the CLI docs this would be `--pod-network-cidr string` in the configuration under `ClusterConfiguration/networking` that field should be set to `podSubnet`. [Reference](https://kubernetes.io/docs/reference/config-api/kubeadm-config.v1beta3/#kubeadm-k8s-io-v1beta3-Networking).