### PR TITLE
Updating setup to support a stand alone router

### DIFF
--- a/HARDWARE.md
+++ b/HARDWARE.md
@@ -6,7 +6,8 @@ This is a summary of the current hardware configuration for the cluster.
 
 |Hostname|Hardware|Storage|
 |--------|--------|-------|
-|node-3|Raspberry Pi 3|64 GB|
-|node-2|Raspberry Pi 4 - 4 GB|32 GB|
-|node-1|Raspberry Pi 5 - 4 GB RAM|128 GB|
-|main-node|Raspberry Pi 4 - 4 GB RAM|64 GB|
+|node-2|Raspberry Pi 3|64 GB|
+|node-1|Raspberry Pi 4 - 4 GB|32 GB|
+|main-node|Raspberry Pi 5 - 4 GB RAM|128 GB|
+|router|Raspberry Pi 4 - 4 GB RAM|64 GB|
+

--- a/NETWORK.md
+++ b/NETWORK.md
@@ -7,23 +7,7 @@ is reserved for UDP multicast.
 
 ## Remote Access
 
-Instructions online all talk of using the main-node as a jump host and once
-SSHed into main-node, SSHing into the other resources from there. A simpler
-solution is going to be installing OpenVPN on main-node and then configuring
-the Ansible controller to tunnel into the cluster network.
+Remove access is through WireGuard running on the router. This will give full
+network access to the cluster, from there kubectl, kubeadm, k9s, or ssh can be
+leveraged.
 
-### OpenVPN Configuration
-
-OpenVPN is configured with the following repo:
-https://github.com/pivpn/pivpn
-
-The current example is the following:
-```BASH
-curl -L https://install.pivpn.io | bash -s --unattended /etc/pivpn/setupVars.conf
-```
-
-This will install OpenVPN on `main-node` with the user `pi` having an OpenVPN
-certificate generated for access to the network.
-
-There might need to be considerations for the configuration. The example
-provided might not support headless/IaC installation.

--- a/README.md
+++ b/README.md
@@ -5,10 +5,10 @@ code needed to setup a simple Raspberry Pi cluster for experimentation.
 
 This will setup four individual nodes:
 
-1. main-node (bridge from the Internet to the cluster network, DHCP)
-2. node-1
-3. node-2
-4. node-3
+1. router (bridge from the Internet to the cluster network, DHCP)
+2. main-node
+3. node-1
+4. node-2
 
 ## Setup Command Computer
 


### PR DESCRIPTION
# Summary

- Part of #8 
- This will setup a router used for jumping into the cluster network
- It **will not** run kubernetes
  - This was decided because firewall settings are updated by kubernetes and were overwriting the configuration needed for WireGuard to work correctly.

# Changes

- Docs updated to reflect changes in hardware